### PR TITLE
fix: Remove Documenter deploydocs to fix permission error

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -25,11 +25,6 @@ makedocs(
     ],
 )
 
-# Only deploy docs when not in a PR
-if get(ENV, "GITHUB_EVENT_NAME", "") != "pull_request"
-    deploydocs(
-        repo = "github.com/pteradigm/RxInferKServe.jl.git",
-        devbranch = "main",
-        push_preview = true,
-    )
-end
+# Deployment is handled by GitHub Actions workflow
+# The docs.yml workflow uses GitHub Pages deployment action
+# which has proper permissions and doesn't require pushing to gh-pages


### PR DESCRIPTION
## Summary

Fix documentation deployment failure caused by permission issues.

## Problem

The documentation build was failing with:
```
remote: Permission to pteradigm/RxInferKServe.jl.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/pteradigm/RxInferKServe.jl.git/': The requested URL returned error: 403
```

## Root Cause

We had two competing deployment mechanisms:
1. **GitHub Actions workflow** (`docs.yml`) - Uses `actions/deploy-pages` with proper permissions ✅
2. **Documenter.jl** (`make.jl`) - Uses `deploydocs()` which tries to push to gh-pages branch ❌

The Documenter.jl deployment was failing because `github-actions[bot]` doesn't have push permissions.

## Solution

Remove the `deploydocs()` call from `docs/make.jl` since deployment is already handled properly by the GitHub Actions workflow. The workflow uses the modern GitHub Pages deployment action which has the correct permissions.

## Impact

- Documentation will build successfully without permission errors
- Deployment will work through GitHub Pages action as intended
- No functional changes to the documentation itself

## Test Plan

- [x] Remove redundant deploydocs call
- [ ] Verify PR documentation builds without errors
- [ ] Confirm deployment works on next main branch push