### PR TITLE
fix: silence successful health probe access logs

### DIFF
--- a/src/server/middleware.jl
+++ b/src/server/middleware.jl
@@ -4,23 +4,32 @@ using HTTP
 using JSON3
 using Dates
 
+const HEALTH_PROBE_PATHS = Set(["/v2/health/live", "/v2/health/ready"])
+
+is_health_probe_path(path::AbstractString) = first(split(path, '?')) in HEALTH_PROBE_PATHS
+
 # Logging middleware
 function logging_middleware(handler)
     return function (request::HTTP.Request)
         start_time = time()
         method = request.method
         path = request.target
+        log_request = !is_health_probe_path(path)
 
         # Generate request ID
         request_id = uuid4()
 
-        @info "Request received" method=method path=path request_id=request_id
+        if log_request
+            @info "Request received" method=method path=path request_id=request_id
+        end
 
         try
             response = handler(request)
             duration_ms = (time() - start_time) * 1000
 
-            @info "Request completed" method=method path=path status=response.status duration_ms=duration_ms request_id=request_id
+            if log_request
+                @info "Request completed" method=method path=path status=response.status duration_ms=duration_ms request_id=request_id
+            end
 
             return response
         catch e

--- a/test/test_server.jl
+++ b/test/test_server.jl
@@ -4,6 +4,14 @@ using HTTP
 using JSON3
 
 @testset "Server" begin
+    @testset "Health probe access logging" begin
+        @test RxInferKServe.is_health_probe_path("/v2/health/live")
+        @test RxInferKServe.is_health_probe_path("/v2/health/ready")
+        @test RxInferKServe.is_health_probe_path("/v2/health/ready?probe=kubernetes")
+        @test !RxInferKServe.is_health_probe_path("/v2/models")
+        @test !RxInferKServe.is_health_probe_path("/v2/models/cortex-unified/ready")
+    end
+
     # Start server on a random port to avoid conflicts
     port = 8080 + rand(1000:9000)
     server = nothing


### PR DESCRIPTION
## Summary
- bring the deployed health-probe logging fix onto main
- keep successful Kubernetes health probes out of request access logs
- preserve logging for ordinary model and API requests

## Validation
- `julia --project=. -e 'using Pkg; Pkg.test()'`
