### PR TITLE
ci: fix release app token input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
     steps:
       - name: Generate release app token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3.2.0
         with:
-          app-id: ${{ vars.PTERADIGM_CI_APP_ID }}
+          client-id: ${{ vars.PTERADIGM_CI_CLIENT_ID }}
           private-key: ${{ secrets.PTERADIGM_CI_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- update release workflow to use the current create-github-app-token client-id input
- align with the existing org-level PTERADIGM_CI_CLIENT_ID variable

## Verification
- actionlint .github/workflows/release.yml