### PR TITLE
ci: configure semantic release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,6 @@ htmlcov/
 logs/
 
 # Semantic Release
-.releaserc.json
 node_modules/
 package-lock.json
 package.json

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,32 @@
+{
+  "branches": ["main"],
+  "repositoryUrl": "https://github.com/pteradigm/RxInferKServe.jl.git",
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
## Summary
- add explicit semantic-release config for GitHub/changelog/git releases
- stop ignoring .releaserc.json so the repo does not fall back to npm defaults

## Verification
- jq . .releaserc.json