### PR TITLE
ci: align docs and release with repository rules

### DIFF
--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -56,7 +56,7 @@ For organizations using GitHub Rulesets (Settings → Rules → Rulesets):
 ## Bypass List
 
 Consider allowing bypass for:
-- Bot accounts (e.g., dependabot, semantic-release bot)
+- Bot accounts that must open or update pull requests (e.g., dependabot)
 - Emergency fixes (with audit trail)
 
 ## Implementation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,6 +75,8 @@ jobs:
       
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
       
       - name: Upload to GitHub Pages
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       
       - name: Install semantic-release
         run: |
-          npm install -g semantic-release @semantic-release/git @semantic-release/github @semantic-release/changelog @semantic-release/exec conventional-changelog-conventionalcommits
+          npm install -g semantic-release @semantic-release/github conventional-changelog-conventionalcommits
       
       - name: Build system image for release
         run: |

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,19 +14,6 @@
         "preset": "conventionalcommits"
       }
     ],
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md"
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary
- let the docs deploy workflow enable GitHub Pages when the site does not exist yet
- remove semantic-release plugins that commit changelog changes directly to protected main
- update branch-protection guidance so release does not require a main-branch bypass

## Validation
- jq . .releaserc.json
- actionlint .github/workflows/release.yml .github/workflows/docs.yml