### PR TITLE
fix: preserve application logging configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       
       - name: Install semantic-release
         run: |
-          npm install -g semantic-release @semantic-release/github conventional-changelog-conventionalcommits
+          npm install -g semantic-release @semantic-release/github @semantic-release/exec @semantic-release/git conventional-changelog-conventionalcommits
       
       - name: Build system image for release
         run: |

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,6 +14,19 @@
         "preset": "conventionalcommits"
       }
     ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "julia --project=. scripts/set_project_version.jl ${nextRelease.version}"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["Project.toml", "Manifest.toml"],
+        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}\n\nSigned-off-by: pteradigm-release[bot] <pteradigm-release[bot]@users.noreply.github.com>"
+      }
+    ],
     "@semantic-release/github"
   ]
 }

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.5"
 manifest_format = "2.0"
-project_hash = "d6b6f6dacc4ee22cc8801f32d77a841534dcf069"
+project_hash = "27c55b6b2cc0ac52c486916f1bb80ddc3a303a5c"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "be7ae030256b8ef14a441726c4c37766b90b93a3"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RxInferKServe"
 uuid = "61c29688-46b5-484d-8dda-4eb83d608538"
 authors = ["Richard Bellamy <rbellamy@pteradigm.com>"]
-version = "0.1.0"
+version = "1.0.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/scripts/set_project_version.jl
+++ b/scripts/set_project_version.jl
@@ -1,0 +1,23 @@
+#!/usr/bin/env julia
+
+using Pkg
+
+if length(ARGS) != 1
+    error("usage: set_project_version.jl <semver-version>")
+end
+
+version = only(ARGS)
+if match(r"^[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.]+)?$", version) === nothing
+    error("version must be a semantic version without a leading v, got $(repr(version))")
+end
+
+project_path = joinpath(@__DIR__, "..", "Project.toml")
+project = read(project_path, String)
+
+if match(r"(?m)^version = \".*\"$", project) === nothing
+    error("Project.toml version field was not updated")
+end
+
+updated = replace(project, r"(?m)^version = \".*\"$" => "version = \"$version\""; count = 1)
+write(project_path, updated)
+Pkg.resolve()

--- a/src/server/config.jl
+++ b/src/server/config.jl
@@ -10,21 +10,28 @@ function init_config(; kwargs...)
     config = ServerConfig(; kwargs...)
     SERVER_CONFIG[] = config
 
-    # Set up logging
-    log_level = config.log_level
-    if log_level == "debug"
-        global_logger(ConsoleLogger(stderr, Logging.Debug))
-    elseif log_level == "info"
-        global_logger(ConsoleLogger(stderr, Logging.Info))
-    elseif log_level == "warn"
-        global_logger(ConsoleLogger(stderr, Logging.Warn))
-    elseif log_level == "error"
-        global_logger(ConsoleLogger(stderr, Logging.Error))
+    if config.configure_global_logger
+        global_logger(ConsoleLogger(stderr, _logging_level(config.log_level)))
     end
 
     @info "Server configuration initialized" host=config.host port=config.port workers=config.workers
 
     return config
+end
+
+function _logging_level(log_level::AbstractString)
+    normalized = lowercase(log_level)
+    if normalized == "debug"
+        return Logging.Debug
+    elseif normalized == "info"
+        return Logging.Info
+    elseif normalized == "warn"
+        return Logging.Warn
+    elseif normalized == "error"
+        return Logging.Error
+    end
+
+    throw(ArgumentError("unsupported log_level: $log_level"))
 end
 
 # Get current configuration

--- a/src/types.jl
+++ b/src/types.jl
@@ -38,6 +38,7 @@ Configuration settings for the RxInferKServe server.
 - `port::Int = 8080`: Server port number
 - `workers::Int = 1`: Number of worker processes
 - `log_level::String = "info"`: Logging level (debug, info, warn, error)
+- `configure_global_logger::Bool = false`: Opt in to configuring Julia's process-global logger
 - `enable_cors::Bool = true`: Enable CORS headers
 - `enable_auth::Bool = false`: Enable API key authentication
 - `api_keys::Vector{String} = String[]`: List of valid API keys
@@ -61,6 +62,7 @@ config = ServerConfig(
     port::Int = 8080
     workers::Int = 1
     log_level::String = "info"
+    configure_global_logger::Bool = false
     enable_cors::Bool = true
     enable_auth::Bool = false
     api_keys::Vector{String} = String[]

--- a/test/test_server.jl
+++ b/test/test_server.jl
@@ -2,8 +2,39 @@ using Test
 using RxInferKServe
 using HTTP
 using JSON3
+using Logging
 
 @testset "Server" begin
+    @testset "Server config does not clobber application logger by default" begin
+        original_logger = global_logger()
+        sink = IOBuffer()
+        application_logger = ConsoleLogger(sink, Logging.Debug)
+
+        try
+            global_logger(application_logger)
+            RxInferKServe.init_config(log_level = "debug")
+
+            @test global_logger() === application_logger
+        finally
+            global_logger(original_logger)
+        end
+    end
+
+    @testset "Server config can opt in to standalone logger setup" begin
+        original_logger = global_logger()
+        sink = IOBuffer()
+        application_logger = ConsoleLogger(sink, Logging.Debug)
+
+        try
+            global_logger(application_logger)
+            RxInferKServe.init_config(log_level = "debug", configure_global_logger = true)
+
+            @test global_logger() !== application_logger
+        finally
+            global_logger(original_logger)
+        end
+    end
+
     @testset "Health probe access logging" begin
         @test RxInferKServe.is_health_probe_path("/v2/health/live")
         @test RxInferKServe.is_health_probe_path("/v2/health/ready")


### PR DESCRIPTION
## Summary
- stop RxInferKServe from overwriting the process-global Julia logger by default
- add explicit opt-in for standalone global logger setup
- add regression tests for embedded service logger preservation

## Verification
- julia --startup-file=no --project=. -e 'using Pkg; Pkg.instantiate(); include("test/test_server.jl")'
- julia --project=. -e 'using Pkg; Pkg.test()'