### PR TITLE
fix: align release workflow with protected main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,7 @@ jobs:
       
       - name: Install semantic-release
         run: |
-          npm install -g semantic-release @semantic-release/github @semantic-release/exec @semantic-release/git conventional-changelog-conventionalcommits
-      
-      - name: Build system image for release
-        run: |
-          julia --project=. -e 'using Pkg; Pkg.instantiate()'
-          julia --project=. scripts/build_sysimage.jl
+          npm install -g semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/github conventional-changelog-conventionalcommits
       
       - name: Run semantic release
         id: semantic

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,19 +14,6 @@
         "preset": "conventionalcommits"
       }
     ],
-    [
-      "@semantic-release/exec",
-      {
-        "prepareCmd": "julia --project=. scripts/set_project_version.jl ${nextRelease.version}"
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["Project.toml", "Manifest.toml"],
-        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}\n\nSigned-off-by: pteradigm-release[bot] <pteradigm-release[bot]@users.noreply.github.com>"
-      }
-    ],
     "@semantic-release/github"
   ]
 }

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RxInferKServe"
 uuid = "61c29688-46b5-484d-8dda-4eb83d608538"
 authors = ["Richard Bellamy <rbellamy@pteradigm.com>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
## Summary
- set the Julia package version to 1.0.1 through a normal PR change
- remove release-time Project.toml/Manifest.toml mutation from semantic-release
- remove the redundant release-time sysimage rebuild before tagging/publishing

## RCA
Release run 28329309709 failed because @semantic-release/git tried to push a generated commit directly to protected main. Repository rules correctly rejected the push because changes must go through PRs, required status checks were expected, and the generated commit was not verified-signed.

## Validation
- jq . .releaserc.json >/dev/null
- julia --project=. -e 'using Pkg; println(Pkg.project().version)'
- git diff --check
- exact check for removed @semantic-release/exec, @semantic-release/git, release sysimage rebuild, and set_project_version references in release config

Signed-off-by: Richard Bellamy <rbellamy@pteradigm.com>